### PR TITLE
feat: reusable Claude PR review workflow with ponytail pass

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -12,10 +12,32 @@
 #         pull-requests: write
 #         id-token: write
 #       secrets: inherit  # or map CLAUDE_CODE_OAUTH_TOKEN explicitly
+#
+# Optional inputs (via `with:`): disable the ponytail pass, install extra
+# plugins, or append review instructions — see the inputs block below.
 name: Claude PR Review
 
 on:
   workflow_call:
+    inputs:
+      ponytail:
+        description: Include the ponytail over-engineering review pass.
+        type: boolean
+        default: true
+      plugins:
+        description: Extra Claude Code plugins to install (newline-separated name@marketplace).
+        type: string
+        default: ""
+      plugin_marketplaces:
+        description: >-
+          Marketplace git URLs for the extra plugins (newline-separated, must
+          end in .git). Unpinned — the action installs their default branch.
+        type: string
+        default: ""
+      extra_instructions:
+        description: Extra instructions appended to the review prompt (e.g. directing Claude to use a custom plugin's skill).
+        type: string
+        default: ""
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         description: Long-lived Claude Code OAuth token; create with `claude setup-token`.
@@ -50,6 +72,7 @@ jobs:
       # upgrade: pick a release from https://github.com/DietrichGebert/ponytail/tags
       # and update the SHA + version comment together.
       - name: Fetch ponytail plugin (v4.8.4, pinned)
+        if: inputs.ponytail
         run: |
           git init -q "$RUNNER_TEMP/ponytail"
           git -C "$RUNNER_TEMP/ponytail" fetch -q --depth 1 \
@@ -76,24 +99,22 @@ jobs:
           use_sticky_comment: true
           # The ponytail plugin supplies the over-engineering review skill
           # used in the prompt below; installed from the commit-pinned clone
-          # fetched above.
-          plugin_marketplaces: ${{ runner.temp }}/ponytail
+          # fetched above. Caller-supplied plugins are appended (the action
+          # trims and drops blank lines, so empty inputs are harmless).
+          plugin_marketplaces: |
+            ${{ inputs.ponytail && format('{0}/ponytail', runner.temp) || '' }}
+            ${{ inputs.plugin_marketplaces }}
           plugins: |
-            ponytail@ponytail
+            ${{ inputs.ponytail && 'ponytail@ponytail' || '' }}
+            ${{ inputs.plugins }}
           prompt: |
             REPO: ${{ github.repository }}
             PR: ${{ github.event.pull_request.number }}
 
-            Review this pull request's diff on two axes:
-
-            1. Correctness: bugs, security issues, and clear best-practice
-               problems. Skip nits and anything a linter or formatter already
-               enforces.
-            2. Over-engineering: apply the ponytail-review skill (from the
-               ponytail plugin) to the same diff — reinvented standard
-               library, unneeded dependencies, speculative abstractions, dead
-               flexibility. One line per finding: location, what to cut, what
-               replaces it.
+            Review this pull request's diff for correctness bugs, security
+            issues, and clear best-practice problems. Skip nits and anything
+            a linter or formatter already enforces.
+            ${{ inputs.ponytail && 'Also apply the ponytail-review skill (from the ponytail plugin) to the same diff, hunting over-engineering: reinvented standard library, unneeded dependencies, speculative abstractions, dead flexibility. One line per finding: location, what to cut, what replaces it. These findings are advisory and never block; list them in a final **Simplify (ponytail)** section, omitted when empty.' || '' }}
 
             Your final message is delivered as the PR review comment
             automatically — do NOT post any comment or review yourself. Just
@@ -101,14 +122,11 @@ jobs:
             - Start with a single bold verdict line: `**✅ No blocking issues
               — safe to merge.**` when nothing is blocking, or `**❌ Changes
               requested — see findings below.**` when there are blocking
-              issues. Only correctness findings block; over-engineering
-              findings are advisory.
-            - Follow with a short bullet list of correctness findings, each
+              issues.
+            - Follow with a short bullet list of blocking findings, each
               citing `path:line` and, where a concrete fix exists, a fenced
               code block with the fix.
-            - End with a `**Simplify (ponytail)**` section listing the
-              over-engineering findings; omit the section when there are
-              none.
             - If nothing is blocking, say so briefly; do not pad.
+            ${{ inputs.extra_instructions }}
           claude_args: |
             --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,115 @@
+# Reusable Claude PR review: correctness and security findings, plus an
+# over-engineering pass via the ponytail plugin's review skill.
+#
+# Call from any repo (see workflow-templates/claude-pr-review.yaml for a
+# complete caller, or the README for secret setup):
+#
+#   jobs:
+#     review:
+#       uses: developmentseed/.github/.github/workflows/claude-pr-review.yml@main
+#       permissions:
+#         contents: read
+#         pull-requests: write
+#         id-token: write
+#       secrets:
+#         CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+name: Claude PR Review
+
+on:
+  workflow_call:
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        description: Long-lived Claude Code OAuth token; create with `claude setup-token`.
+        required: true
+
+jobs:
+  review:
+    # Skip PRs authored by bots (dependabot etc.). allowed_bots below is
+    # different: it lets the github-actions bot *trigger* reviews of PRs
+    # authored by humans or Claude.
+    if: github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    # Cancel an in-flight review when a new commit is pushed: the latest
+    # commit is the only one worth reviewing, and all runs share one sticky
+    # comment anyway.
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      # Fetch the ponytail plugin pinned to an exact commit (v4.8.4) so the
+      # review can't silently pick up new third-party code. The action's
+      # plugin_marketplaces input takes raw git URLs with no ref support, but
+      # it accepts local paths — so pin here and hand it the clone. To
+      # upgrade: pick a release from https://github.com/DietrichGebert/ponytail/tags
+      # and update the SHA + version comment together.
+      - name: Fetch ponytail plugin (v4.8.4, pinned)
+        run: |
+          git init -q "$RUNNER_TEMP/ponytail"
+          git -C "$RUNNER_TEMP/ponytail" fetch -q --depth 1 \
+            https://github.com/DietrichGebert/ponytail.git \
+            bc9ee949d5f439e8b9f3bb92c6d6d3d1e6ebd324
+          git -C "$RUNNER_TEMP/ponytail" checkout -q FETCH_HEAD
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Allow the github-actions bot to trigger the review so that
+          # Claude-authored PRs get reviewed. Without this, the action
+          # aborts on bot actors ("Workflow initiated by non-human actor").
+          allowed_bots: "github-actions"
+          # Deliver the review as ONE sticky PR comment that updates in place
+          # each run. track_progress forces tag mode (a single tracking
+          # comment the action owns and updates with the final result on
+          # these pull_request events); use_sticky_comment makes it the SAME
+          # comment across pushes. A formal-review approach instead leaves
+          # multiple reviews per run and accumulates undismissable COMMENTED
+          # reviews across runs (GitHub can't dismiss or delete a submitted
+          # COMMENTED review).
+          track_progress: true
+          use_sticky_comment: true
+          # The ponytail plugin supplies the over-engineering review skill
+          # used in the prompt below; installed from the commit-pinned clone
+          # fetched above.
+          plugin_marketplaces: ${{ runner.temp }}/ponytail
+          plugins: |
+            ponytail@ponytail
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR: ${{ github.event.pull_request.number }}
+
+            Review this pull request's diff on two axes:
+
+            1. Correctness: bugs, security issues, and clear best-practice
+               problems. Skip nits and anything a linter or formatter already
+               enforces.
+            2. Over-engineering: apply the ponytail-review skill (from the
+               ponytail plugin) to the same diff — reinvented standard
+               library, unneeded dependencies, speculative abstractions, dead
+               flexibility. One line per finding: location, what to cut, what
+               replaces it.
+
+            Your final message is delivered as the PR review comment
+            automatically — do NOT post any comment or review yourself. Just
+            produce the review:
+            - Start with a single bold verdict line: `**✅ No blocking issues
+              — safe to merge.**` when nothing is blocking, or `**❌ Changes
+              requested — see findings below.**` when there are blocking
+              issues. Only correctness findings block; over-engineering
+              findings are advisory.
+            - Follow with a short bullet list of correctness findings, each
+              citing `path:line` and, where a concrete fix exists, a fenced
+              code block with the fix.
+            - End with a `**Simplify (ponytail)**` section listing the
+              over-engineering findings; omit the section when there are
+              none.
+            - If nothing is blocking, say so briefly; do not pad.
+          claude_args: |
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -38,6 +38,10 @@ on:
         description: Extra instructions appended to the review prompt (e.g. directing Claude to use a custom plugin's skill).
         type: string
         default: ""
+      show_cost:
+        description: Append the estimated review cost to the PR review comment.
+        type: boolean
+        default: true
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         description: Long-lived Claude Code OAuth token; create with `claude setup-token`.
@@ -81,6 +85,7 @@ jobs:
           git -C "$RUNNER_TEMP/ponytail" checkout -q FETCH_HEAD
 
       - uses: anthropics/claude-code-action@v1
+        id: claude
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Allow the github-actions bot to trigger the review so that
@@ -130,3 +135,32 @@ jobs:
             ${{ inputs.extra_instructions }}
           claude_args: |
             --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*)"
+
+      # The action has no built-in cost display, but its execution log's
+      # final result record carries the run metrics — append them to the
+      # review comment. The sticky comment has no marker; find it the way
+      # the action itself does (latest comment by a claude bot), and PATCH
+      # with the action's own token so we edit as the comment's author.
+      # With subscription (OAuth) auth the cost is the API-equivalent
+      # estimate, not an actual charge.
+      - name: Append cost to review comment
+        if: inputs.show_cost && steps.claude.outputs.execution_file != ''
+        env:
+          GH_TOKEN: ${{ steps.claude.outputs.github_token || github.token }}
+          EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          read -r cost ms turns < <(jq -r '[.[] | select(.type=="result")] | last |
+            if . == null then "" else "\(.total_cost_usd) \(.duration_ms | floor) \(.num_turns)" end' \
+            "$EXECUTION_FILE") || true
+          if [ -z "${cost:-}" ] || [ "$cost" = "null" ]; then exit 0; fi
+          footer=$(printf '\n\n---\n*💰 Estimated review cost: $%.2f · %dm%02ds · %s turns*' \
+            "$cost" $((ms / 60000)) $((ms / 1000 % 60)) "$turns")
+          id=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --paginate \
+            --jq '.[] | select(.user.type == "Bot" and (.user.login | ascii_downcase | contains("claude"))) | .id' \
+            | tail -1)
+          if [ -z "$id" ]; then exit 0; fi
+          gh api "repos/$GITHUB_REPOSITORY/issues/comments/$id" --jq .body > "$RUNNER_TEMP/body.md"
+          printf '%s' "$footer" >> "$RUNNER_TEMP/body.md"
+          gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$id" \
+            -F body=@"$RUNNER_TEMP/body.md" > /dev/null

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -11,8 +11,7 @@
 #         contents: read
 #         pull-requests: write
 #         id-token: write
-#       secrets:
-#         CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+#       secrets: inherit  # or map CLAUDE_CODE_OAUTH_TOKEN explicitly
 name: Claude PR Review
 
 on:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ jobs:
     secrets: inherit
 ```
 
+All inputs are optional (pass under `with:`):
+
+- `ponytail` (default `true`) — set `false` to drop the over-engineering pass.
+- `plugins` / `plugin_marketplaces` — install your own Claude Code plugins (newline-separated `name@marketplace` and marketplace `.git` URLs). Caller-supplied marketplaces install unpinned from their default branch — only the built-in ponytail install is pinned to an exact commit.
+- `extra_instructions` — text appended to the review prompt, e.g. to direct Claude to use a custom plugin's skill.
+
 `secrets: inherit` picks up the org-level `CLAUDE_CODE_OAUTH_TOKEN` secret, so most repos need no secret setup at all. To use a different token for one repo, either add a repo-level secret with the same name (it shadows the org secret), or map one explicitly instead of inheriting:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -10,6 +10,39 @@ Recommended reading:
 - [Creating starter workflows](https://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization)
 - [Using starter workflows](https://docs.github.com/en/actions/using-workflows/using-starter-workflows)
 
+### Claude PR Review
+
+[`claude-pr-review.yml`](.github/workflows/claude-pr-review.yml) has Claude review every pull request for correctness and security issues, plus an over-engineering pass via the [ponytail](https://github.com/DietrichGebert/ponytail) review skill. Findings land in one sticky PR comment that updates in place on every push.
+
+Add it to a repo (or pick the "Claude PR Review" starter workflow under Actions → New workflow):
+
+```yaml
+# .github/workflows/claude-review.yml
+name: Claude Auto Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    paths-ignore:
+      - '.github/workflows/**'
+
+jobs:
+  review:
+    uses: developmentseed/.github/.github/workflows/claude-pr-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+```
+
+#### Creating the `CLAUDE_CODE_OAUTH_TOKEN` secret
+
+1. On a machine with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and logged in with a Claude subscription (Pro/Max), run `claude setup-token`.
+2. Approve the OAuth flow in the browser and copy the generated long-lived token (starts with `sk-ant-oat01-`).
+3. Save it as an Actions secret named `CLAUDE_CODE_OAUTH_TOKEN` — at the org level (Settings → Secrets and variables → Actions → New organization secret) so every repo can use it, or per-repo.
+
 
 ## Multiple Pull Request templates
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ All inputs are optional (pass under `with:`):
 - `ponytail` (default `true`) — set `false` to drop the over-engineering pass.
 - `plugins` / `plugin_marketplaces` — install your own Claude Code plugins (newline-separated `name@marketplace` and marketplace `.git` URLs). Caller-supplied marketplaces install unpinned from their default branch — only the built-in ponytail install is pinned to an exact commit.
 - `extra_instructions` — text appended to the review prompt, e.g. to direct Claude to use a custom plugin's skill.
+- `show_cost` (default `true`) — appends the estimated review cost (API-equivalent), duration, and turn count to the review comment; set `false` to hide.
 
 `secrets: inherit` picks up the org-level `CLAUDE_CODE_OAUTH_TOKEN` secret, so most repos need no secret setup at all. To use a different token for one repo, either add a repo-level secret with the same name (it shadows the org secret), or map one explicitly instead of inheriting:
 

--- a/README.md
+++ b/README.md
@@ -33,15 +33,21 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
+    secrets: inherit
+```
+
+`secrets: inherit` picks up the org-level `CLAUDE_CODE_OAUTH_TOKEN` secret, so most repos need no secret setup at all. To use a different token for one repo, either add a repo-level secret with the same name (it shadows the org secret), or map one explicitly instead of inheriting:
+
+```yaml
     secrets:
-      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.MY_OTHER_TOKEN }}
 ```
 
 #### Creating the `CLAUDE_CODE_OAUTH_TOKEN` secret
 
 1. On a machine with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and logged in with a Claude subscription (Pro/Max), run `claude setup-token`.
 2. Approve the OAuth flow in the browser and copy the generated long-lived token (starts with `sk-ant-oat01-`).
-3. Save it as an Actions secret named `CLAUDE_CODE_OAUTH_TOKEN` — at the org level (Settings → Secrets and variables → Actions → New organization secret) so every repo can use it, or per-repo.
+3. Save it as an Actions secret named `CLAUDE_CODE_OAUTH_TOKEN` — at the org level (Settings → Secrets and variables → Actions → New organization secret) so every repo gets it via `secrets: inherit`, or per-repo. The token bills the subscription of whoever ran `setup-token`, so prefer a service/bot account for the org secret.
 
 
 ## Multiple Pull Request templates

--- a/workflow-templates/claude-pr-review.properties.json
+++ b/workflow-templates/claude-pr-review.properties.json
@@ -1,0 +1,8 @@
+{
+    "name": "Claude PR Review",
+    "description": "Claude reviews every pull request for correctness and security issues, plus an over-engineering pass via the ponytail review skill. Posts one sticky comment per PR that updates on every push. Requires the CLAUDE_CODE_OAUTH_TOKEN secret.",
+    "categories": [
+        "code-review",
+        "automation"
+    ]
+}

--- a/workflow-templates/claude-pr-review.yaml
+++ b/workflow-templates/claude-pr-review.yaml
@@ -16,7 +16,12 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    secrets:
-      # Create with `claude setup-token`; see
-      # https://github.com/developmentseed/.github#claude-pr-review
-      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    # Picks up the org-level CLAUDE_CODE_OAUTH_TOKEN secret (create with
+    # `claude setup-token`; see
+    # https://github.com/developmentseed/.github#claude-pr-review).
+    # To use a different token for this repo, either add a repo-level
+    # secret with the same name (it shadows the org secret), or replace
+    # `inherit` with an explicit mapping:
+    #   secrets:
+    #     CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.MY_OTHER_TOKEN }}
+    secrets: inherit

--- a/workflow-templates/claude-pr-review.yaml
+++ b/workflow-templates/claude-pr-review.yaml
@@ -1,0 +1,22 @@
+name: Claude Auto Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Skip when a PR touches workflow files: the action can't validate/run
+    # against modified workflows and fails with "401 Unauthorized - Workflow
+    # validation failed".
+    paths-ignore:
+      - '.github/workflows/**'
+
+jobs:
+  review:
+    uses: developmentseed/.github/.github/workflows/claude-pr-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    secrets:
+      # Create with `claude setup-token`; see
+      # https://github.com/developmentseed/.github#claude-pr-review
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/workflow-templates/claude-pr-review.yaml
+++ b/workflow-templates/claude-pr-review.yaml
@@ -12,6 +12,15 @@ on:
 jobs:
   review:
     uses: developmentseed/.github/.github/workflows/claude-pr-review.yml@main
+    # All inputs are optional:
+    # with:
+    #   ponytail: false            # drop the over-engineering pass
+    #   plugins: |                 # install your own plugins...
+    #     my-plugin@my-marketplace
+    #   plugin_marketplaces: |
+    #     https://github.com/my-org/my-marketplace.git
+    #   extra_instructions: |      # ...and tell the reviewer to use them
+    #     Also apply the my-plugin review skill.
     permissions:
       contents: read
       pull-requests: write

--- a/workflow-templates/claude-pr-review.yaml
+++ b/workflow-templates/claude-pr-review.yaml
@@ -21,6 +21,7 @@ jobs:
     #     https://github.com/my-org/my-marketplace.git
     #   extra_instructions: |      # ...and tell the reviewer to use them
     #     Also apply the my-plugin review skill.
+    #   show_cost: false           # hide the cost footer on the comment
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Adds an org-wide reusable workflow that has Claude review every pull request, ported from [source-cooperative/source.coop's `pr-review-comprehensive.yml`](https://github.com/source-cooperative/source.coop/blob/main/.github/workflows/pr-review-comprehensive.yml) and extended with an over-engineering review pass via the [ponytail](https://github.com/DietrichGebert/ponytail) plugin.

## What's included

- **`.github/workflows/claude-pr-review.yml`** — the reusable (`workflow_call`) workflow. Reviews the PR diff for correctness/security issues (blocking) and, by default, over-engineering via the ponytail review skill (advisory, listed in a separate **Simplify (ponytail)** section). Findings land in one sticky PR comment that updates in place on every push, with an estimated-cost footer appended after each run; in-flight reviews are cancelled when a new commit arrives. The ponytail pass, extra plugins, prompt additions, and cost footer are all configurable via inputs (see Configuration below).
- **`workflow-templates/claude-pr-review.yaml`** — starter workflow, so any org repo can adopt this from **Actions → New workflow** (matches this repo's existing template convention).
- **README** — usage snippet and token setup docs.

## Usage from any repo

```yaml
# .github/workflows/claude-review.yml
name: Claude Auto Review

on:
  pull_request:
    types: [opened, synchronize, ready_for_review, reopened]
    paths-ignore:
      - '.github/workflows/**'   # action can't run against modified workflows

jobs:
  review:
    uses: developmentseed/.github/.github/workflows/claude-pr-review.yml@main
    permissions:
      contents: read
      pull-requests: write
      id-token: write
    secrets: inherit
```

`secrets: inherit` picks up the org-level `CLAUDE_CODE_OAUTH_TOKEN` secret, so most repos need zero secret setup. To override for one repo: add a repo-level secret with the same name (it shadows the org secret), or map one explicitly — `secrets: { CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.MY_OTHER_TOKEN }} }`.

## Creating the `CLAUDE_CODE_OAUTH_TOKEN` secret

The workflow authenticates with a long-lived Claude Code OAuth token (billed to a Claude subscription, not API credits):

1. On a machine with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and logged in with a Claude Pro/Max subscription, run:
   ```sh
   claude setup-token
   ```
2. Approve the OAuth flow in the browser, then copy the generated token (starts with `sk-ant-oat01-`).
3. Save it as an Actions secret named `CLAUDE_CODE_OAUTH_TOKEN`:
   - **Org-level** (recommended): org **Settings → Secrets and variables → Actions → New organization secret**, so every repo calling this workflow picks it up via the one-line `secrets: inherit` above.
   - Or per-repo under the repo's Actions secrets.

The token belongs to whichever account ran `setup-token`, so prefer a service/bot account for the org secret. Revoke/rotate by re-running `claude setup-token` and updating the secret.

## Configuration

All `with:` inputs are optional; the zero-config default is the full review with the ponytail pass:

- `ponytail` (default `true`) — set `false` to drop the over-engineering pass entirely (no plugin install, no prompt section).
- `plugins` / `plugin_marketplaces` — install arbitrary Claude Code plugins (newline-separated `name@marketplace` entries and marketplace `.git` URLs). Note: caller-supplied marketplaces install unpinned from their default branch — the action's marketplace input has no ref support; only the built-in ponytail install is SHA-pinned.
- `extra_instructions` — text appended to the review prompt, e.g. to direct Claude to use a custom plugin's review skill.
- `show_cost` (default `true`) — after the review, a follow-up step appends the estimated cost, duration, and turn count to the review comment (e.g. `💰 Estimated review cost: $0.43 · 5m32s · 12 turns`). The action exposes no built-in cost display, so the step reads the run metrics from the action's `execution_file` output and PATCHes the sticky comment using the action's own token (editing it as its author). With OAuth/subscription auth the figure is the API-equivalent estimate, not an actual charge.

```yaml
    with:
      ponytail: false
      plugin_marketplaces: |
        https://github.com/my-org/my-marketplace.git
      plugins: |
        my-plugin@my-marketplace
      extra_instructions: |
        Also apply the my-plugin review skill.
```

Since a `workflow_call` workflow can't run pre-merge without a caller repo on a `pull_request` event, the first adopting repo is the end-to-end smoke test.

## Ponytail integration & supply-chain pinning

The ponytail plugin is pinned to its latest release, **v4.8.4**, by exact commit (`bc9ee94`): `claude-code-action`'s `plugin_marketplaces` input only takes raw git URLs with no ref support, so the workflow fetches the marketplace repo at the pinned SHA in a separate step and hands the action the local clone. Upgrading the plugin = updating one SHA in one file, and every repo in the org picks it up.

Skipped, add when needed: a model-choice input and an `anthropic_api_key` auth path — today every caller gets subscription billing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
