### PR TITLE
fix: cost-footer 401 (revoked app token) + model input

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -139,14 +139,17 @@ jobs:
       # The action has no built-in cost display, but its execution log's
       # final result record carries the run metrics — append them to the
       # review comment. The sticky comment has no marker; find it the way
-      # the action itself does (latest comment by a claude bot), and PATCH
-      # with the action's own token so we edit as the comment's author.
-      # With subscription (OAuth) auth the cost is the API-equivalent
-      # estimate, not an actual charge.
+      # the action itself does (latest comment by a claude bot). Use the
+      # job's own token: the action's github_token output is a Claude App
+      # token that the action revokes in its own final step, so it is
+      # always dead (401) by the time this step runs. Failures here warn
+      # instead of failing the job — a missing footer is not worth a red X
+      # on the PR. With subscription (OAuth) auth the cost is the
+      # API-equivalent estimate, not an actual charge.
       - name: Append cost to review comment
         if: inputs.show_cost && steps.claude.outputs.execution_file != ''
         env:
-          GH_TOKEN: ${{ steps.claude.outputs.github_token || github.token }}
+          GH_TOKEN: ${{ github.token }}
           EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
@@ -158,9 +161,19 @@ jobs:
             "$cost" $((ms / 60000)) $((ms / 1000 % 60)) "$turns")
           id=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --paginate \
             --jq '.[] | select(.user.type == "Bot" and (.user.login | ascii_downcase | contains("claude"))) | .id' \
-            | tail -1)
-          if [ -z "$id" ]; then exit 0; fi
-          gh api "repos/$GITHUB_REPOSITORY/issues/comments/$id" --jq .body > "$RUNNER_TEMP/body.md"
+            | tail -1) || true
+          # gh prints the error body to stdout on API failures, so require a
+          # numeric id rather than merely a non-empty one.
+          if ! [[ "$id" =~ ^[0-9]+$ ]]; then
+            echo "::warning::cost footer skipped: no review comment found"
+            exit 0
+          fi
+          if ! gh api "repos/$GITHUB_REPOSITORY/issues/comments/$id" --jq .body > "$RUNNER_TEMP/body.md"; then
+            echo "::warning::cost footer skipped: could not read comment $id"
+            exit 0
+          fi
           printf '%s' "$footer" >> "$RUNNER_TEMP/body.md"
-          gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$id" \
-            -F body=@"$RUNNER_TEMP/body.md" > /dev/null
+          if ! gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$id" \
+              -F body=@"$RUNNER_TEMP/body.md" > /dev/null; then
+            echo "::warning::cost footer skipped: could not update comment $id"
+          fi

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -42,6 +42,10 @@ on:
         description: Append the estimated review cost to the PR review comment.
         type: boolean
         default: true
+      model:
+        description: Model for the review (e.g. claude-opus-4-8); empty uses the Claude Code default.
+        type: string
+        default: ""
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         description: Long-lived Claude Code OAuth token; create with `claude setup-token`.
@@ -135,6 +139,7 @@ jobs:
             ${{ inputs.extra_instructions }}
           claude_args: |
             --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*)"
+            ${{ inputs.model && format('--model {0}', inputs.model) || '' }}
 
       # The action has no built-in cost display, but its execution log's
       # final result record carries the run metrics — append them to the

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ All inputs are optional (pass under `with:`):
 - `plugins` / `plugin_marketplaces` — install your own Claude Code plugins (newline-separated `name@marketplace` and marketplace `.git` URLs). Caller-supplied marketplaces install unpinned from their default branch — only the built-in ponytail install is pinned to an exact commit.
 - `extra_instructions` — text appended to the review prompt, e.g. to direct Claude to use a custom plugin's skill.
 - `show_cost` (default `true`) — appends the estimated review cost (API-equivalent), duration, and turn count to the review comment; set `false` to hide.
+- `model` — model ID for the review (e.g. `claude-opus-4-8` for a more capable review). Empty uses Claude Code's default model (currently a Sonnet-tier model). Note: with subscription auth, bigger models consume the plan's usage quota faster.
 
 `secrets: inherit` picks up the org-level `CLAUDE_CODE_OAUTH_TOKEN` secret, so most repos need no secret setup at all. To use a different token for one repo, either add a repo-level secret with the same name (it shadows the org secret), or map one explicitly instead of inheriting:
 

--- a/workflow-templates/claude-pr-review.yaml
+++ b/workflow-templates/claude-pr-review.yaml
@@ -22,6 +22,7 @@ jobs:
     #   extra_instructions: |      # ...and tell the reviewer to use them
     #     Also apply the my-plugin review skill.
     #   show_cost: false           # hide the cost footer on the comment
+    #   model: claude-opus-4-8     # review model (default: Claude Code default)
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Fixes the cost-footer 401 seen in [multistore run 29125093769](https://github.com/developmentseed/multistore/actions/runs/29125093769/job/86469387182?pr=108), and adds a `model` input.

## Bug: cost footer failed with `gh: Bad credentials (HTTP 401)`

Root cause: the step authenticated with `steps.claude.outputs.github_token` (the Claude App installation token) to edit the comment as its author — but `claude-code-action`'s own final composite step is **"Revoke app token"** (`if: always()`), so that token is always dead by the time any follow-up step runs. Both `gh` calls 401'd. A second latent bug made it a hard failure instead of a silent skip: `gh api` prints the error body to **stdout**, so `tail -1` captured a junk line as the comment id, the follow-up call also failed, and `bash -e` failed the step.

Fixes:
- Authenticate with the job's own `github.token` (already granted `pull-requests: write` by callers). This edits the claude[bot] comment cross-author, which write-access tokens are permitted to do — if GitHub ever denies it, the new warning path will say so rather than fail.
- Require the comment id to be numeric, not merely non-empty.
- Degrade all failures in this step to `::warning::` annotations — a missing cost footer is not worth a red X on someone's PR.

## Feature: `model` input

Callers can now pick the review model (empty default = Claude Code's default, currently Sonnet-tier):

```yaml
    with:
      model: claude-opus-4-8
```

Passed through as `--model` in `claude_args`. Documented in the README and starter template, with a note that bigger models consume subscription quota faster.

Validation: YAML parses; the failure path logic mirrors the flow observed in the failed run's log. Real-run validation happens on the next PR push in an adopting repo (the failed step is downstream of the review itself, which worked — including the $1.57 cost record this step will now render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
